### PR TITLE
refactor: Replace `any` with `unknown`

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,0 +1,17 @@
+import {hasActionInput} from '../src/utils'
+import {env} from 'process'
+
+describe('utils', () => {
+  beforeEach(() => {
+    env['INPUT_EMPTY_STRING'] = '';
+  })
+
+  test('differentiates between absence of value and empty string', () => {
+    expect(hasActionInput('empty_string')).toStrictEqual(true)
+    expect(hasActionInput('parameter_not_provided')).toStrictEqual(false)
+  })
+
+  afterEach(() => {
+    delete env['INPUT_EMPTY_STRING'];
+  })
+})

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -6,8 +6,7 @@ export interface Result {
 }
 
 export interface Assertion {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (expected: any, actual: any): Result
+  (expected: unknown, actual: unknown): Result
 }
 
 export interface Test {

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -7,8 +7,7 @@ export enum InputType {
 }
 
 export interface Input {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  value: any
+  value: unknown
   type: InputType
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core'
 import {executeTests, Test, Assertion} from './execute'
 import {InputType} from './inputs'
 import {resolveAssertion} from './assertions'
-import {env} from 'process'
+import {hasActionInput} from './utils'
 
 const types = {
   string: InputType.String,
@@ -10,18 +10,12 @@ const types = {
   json: InputType.Json
 }
 
-function hasInput(name: string): boolean {
-  const envKey = `INPUT_${name.replace(/ /g, '_').toUpperCase()}`
-
-  return envKey in process.env
-}
-
 async function run(): Promise<void> {
   try {
-    const expected: string | null = hasInput('expected')
+    const expected: string | null = hasActionInput('expected')
       ? core.getInput('expected')
       : null
-    const actual: string | null = hasInput('actual')
+    const actual: string | null = hasActionInput('actual')
       ? core.getInput('actual')
       : null
     const assertion: string = core.getInput('assertion')

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,5 @@
+import {env} from 'process'
+
+export function hasActionInput(name: string): boolean {
+  return `INPUT_${name.replace(/ /g, '_').toUpperCase()}` in env
+}


### PR DESCRIPTION
The action needs to accept inputs of an unknown type, but the type is declared before performing any operation so `unknown` is a type-safe alternative to `any`.

> TypeScript 3.0 introduces a new top type unknown. unknown is the type-safe counterpart of any. Anything is assignable to unknown, but unknown isn’t assignable to anything but itself and any without a type assertion or a control flow based narrowing. Likewise, no operations are permitted on an unknown without first asserting or narrowing to a more specific type.

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-0.html#new-unknown-top-type