### PR TITLE
feat: Add `passed` output as alias of `pass`

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -141,3 +141,9 @@ jobs:
           assertion: npm://@assertions/is-equal
           actual: "${{ steps.equal-strings.outputs.pass }}"
           expected: "true"
+      - name: Test `passed` has the same value as `pass`
+        uses: ./
+        with:
+          assertion: npm://@assertions/is-equal
+          expected: "${{ steps.equal-strings.outputs.pass }}"
+          actual: "${{ steps.equal-strings.outputs.passed }}"

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ assertion to be discoverable via [npm search<sup>&neArr;</sup>][npm/search].
 | Name | Description | Example |
 | :--- | :---------- | :-------|
 | `message` | Human readable result of the assertion | `Value is Hello, World!` |
-| `pass` | Boolean describing whether the assertion passed | `true` |
+| `passed` | Boolean describing whether the assertion passed | `true` |
 
 ## Examples
 

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,8 @@ outputs:
     description: "Human readable result of the assertion"
   pass:
     description: "Boolean describing whether the assertion passed"
+  passed:
+    description: "Boolean describing whether the assertion passed"
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,6 +58,7 @@ async function run(): Promise<void> {
 
       core.setOutput('message', result.message)
       core.setOutput('pass', result.pass.toString())
+      core.setOutput('passed', result.pass.toString())
     })
   } catch (error) {
     core.setFailed(error.message)


### PR DESCRIPTION
The `pass` output name is not consistent with the language used in the project and will be deprecated in future -- for now, adding an alias with the right name improves usability without breaking compatibility.

- [x] Closes #43 