### PR TITLE
feat: Report error with custom error message

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -358,8 +358,8 @@ jobs:
         with:
           name: dist
           path: ${{ env.dist-path }}
-      - name: Test two different strings are equal
-        id: equal-strings
+      - name: Perform failing assertion with custom Error Message
+        id: with-error-message
         continue-on-error: true
         uses: ./
         with:
@@ -367,9 +367,23 @@ jobs:
           actual: "Bye bye!"
           expected: "Goodbye, World!"
           error-message: "The two different strings are not equal"
-      - name: Test previous step failed
+      - name: Test custom Error Message is used
         uses: ./
         with:
           assertion: npm://@assertions/is-equal:v1
-          expected: "failure"
-          actual: "${{ steps.equal-strings.outcome }}"
+          expected: "The two different strings are not equal"
+          actual: "${{ steps.with-error-message.outputs.error }}"
+      - name: Perform failing assertion without custom Error Message
+        id: without-error-message
+        continue-on-error: true
+        uses: ./
+        with:
+          assertion: local://.github/workflows/assertions/is-equal
+          actual: "Bye bye!"
+          expected: "Goodbye, World!"
+      - name: Test assertion message is used as default error
+        uses: ./
+        with:
+          assertion: npm://@assertions/is-equal:v1
+          expected: "compared Bye bye! to Goodbye, World!"
+          actual: "${{ steps.without-error-message.outputs.error }}"

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -348,3 +348,28 @@ jobs:
           actual: "Bye bye!"
           expected: "Goodbye, World!"
           error-on-fail: false
+  test-error-message:
+    runs-on: ubuntu-latest
+    needs:
+      - upload-dist
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: ${{ env.dist-path }}
+      - name: Test two different strings are equal
+        id: equal-strings
+        continue-on-error: true
+        uses: ./
+        with:
+          assertion: local://.github/workflows/assertions/is-equal
+          actual: "Bye bye!"
+          expected: "Goodbye, World!"
+          error-message: "The two different strings are not equal"
+      - name: Test previous step failed
+        uses: ./
+        with:
+          assertion: npm://@assertions/is-equal:v1
+          expected: "failure"
+          actual: "${{ steps.equal-strings.outcome }}"

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ jobs:
 | **`assertion`** | **Reference to a supported [assertion](#assertions) in `source://name` format** | | **`npm://@assertions/is-equal:v1`**<br/>**`local://is-even`** |
 | `expected` | Value the assertion is looking for | | `Hello, World!` |
 | `actual` | Value the assertion will test against the expected value | | `${{steps.fields.outputs.greeting}}` |
+| `error-message` | Error message to output when assertion fails |  | `Commit does not include a distributable build` |
 | `type` | A supported [data type](#data-types) that `actual` and `expected` will be cast to before performing assertion | `string` | `string` `json` `number` |
 | `each` | Parse multi-line `actual` into many values and perform assertion against each | `false` | `true` `false` |
 | `local-path` | Path to directory containing `local` assertion | `${{github.workspace}}` | `.github/workflows/assertions` |
 | `error-on-fail` | Report error in step when assertion fails | `true` | `false` |
-| `error-message` | Error message to output when assertion fails |  | `Commit does not include a distributable build` |
 | `convert-empty-to-null`<sup>[1]</sup> | Convert empty input values to null | `true` | `false` |
 
 [1] `convert-empty-to-null` is a workaround for a
@@ -154,6 +154,7 @@ jobs:
           each: true
           actual: "${{ steps.prefixed.outputs.list }}"
           expected: "v"
+          error-message: "SemVer Alias is not prefixed with v"
 ```
 
 A complete test Workflow for [pr-mpt/actions-semver-aliases] using multiple
@@ -181,6 +182,7 @@ jobs:
         with:
           assertion: npm://@assertions/directory-exists:v1
           expected: dist
+          error-message: "A commit without a dist is not allowed to be tagged"
       - if: failure()
         name: Delete tag
         uses: pr-mpt/actions-delete-tag@v1

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ jobs:
 | `each` | Parse multi-line `actual` into many values and perform assertion against each | `false` | `true` `false` |
 | `local-path` | Path to directory containing `local` assertion | `${{github.workspace}}` | `.github/workflows/assertions` |
 | `error-on-fail` | Report error in step when assertion fails | `true` | `false` |
+| `error-message` | Error message to output when assertion fails |  | `Commit does not include a distributable build` |
 | `convert-empty-to-null`<sup>[1]</sup> | Convert empty input values to null | `true` | `false` |
 
 [1] `convert-empty-to-null` is a workaround for a

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,9 @@ inputs:
     description: "Report error in step when assertion fails"
     default: "true"
     required: true
+  error-message:
+    description: "Error message to output when assertion fails"
+    required: false
   convert-empty-to-null:
     description: "Convert empty input values to null"
     default: "true"

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,8 @@ outputs:
     description: "Boolean describing whether the assertion passed"
   failed:
     description: "Boolean describing whether the assertion failed"
+  error:
+    description: "Error message (if any) that has been output to the log"
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,8 +23,8 @@ async function run(): Promise<void> {
     const each: boolean = core.getBooleanInput('each')
     const localPath: string = core.getInput('local-path')
     const errorOnFail: boolean = core.getBooleanInput('error-on-fail')
-    const errorMessage: string | null = hasActionInput('errorMessage')
-      ? core.getInput('errorMessage')
+    const errorMessage: string | null = hasActionInput('error-message')
+      ? core.getInput('error-message')
       : null
 
     if (type in types === false) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ async function run(): Promise<void> {
     const each: boolean = core.getBooleanInput('each')
     const localPath: string = core.getInput('local-path')
     const errorOnFail: boolean = core.getBooleanInput('error-on-fail')
+    const errorMessage: string = core.getInput('error-message')
 
     if (type in types === false) {
       throw new Error(
@@ -61,7 +62,7 @@ async function run(): Promise<void> {
     const aggregateResult: AggregateResult = new AggregateResult(results)
 
     if (!aggregateResult.pass && errorOnFail) {
-      core.setFailed(aggregateResult.message)
+      core.setFailed(errorMessage ?? aggregateResult.message)
     }
 
     core.setOutput('message', aggregateResult.message)

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,7 +64,9 @@ async function run(): Promise<void> {
     const aggregateResult: AggregateResult = new AggregateResult(results)
 
     if (!aggregateResult.pass && errorOnFail) {
-      core.setFailed(errorMessage ?? aggregateResult.message)
+      const error: string = errorMessage ?? aggregateResult.message
+      core.setFailed(error)
+      core.setOutput('error', error)
     }
 
     core.setOutput('message', aggregateResult.message)

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,9 @@ async function run(): Promise<void> {
     const each: boolean = core.getBooleanInput('each')
     const localPath: string = core.getInput('local-path')
     const errorOnFail: boolean = core.getBooleanInput('error-on-fail')
-    const errorMessage: string = core.getInput('error-message')
+    const errorMessage: string | null = hasActionInput('errorMessage')
+      ? core.getInput('errorMessage')
+      : null
 
     if (type in types === false) {
       throw new Error(


### PR DESCRIPTION
Closes #57

Unfortunately, there doesn't appear to be a way to (reliably) test the _actual_ error message outputs so I've added a new `error` output that isn't intended to be used for anything other than these integration tests. 